### PR TITLE
Add shared commands repository structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,35 @@
 # claude-code-boosters
+
 ShakaCode Team Shared Claude Code Commands, Agents, Skills, Tips
+
+## About
+
+This repository contains shared resources for the ShakaCode team to enhance their Claude Code workflows:
+
+- **Commands**: Custom slash commands for common development tasks
+- **Agents**: Specialized agents for specific workflows
+- **Skills**: Reusable skill definitions
+- **Tips**: Best practices and workflow optimizations
+
+## Commands
+
+### `/address-review`
+
+Fetch GitHub PR review comments and create todos to address them.
+
+**Usage:**
+- `/address-review 12345` - Fetch all comments from PR #12345
+- `/address-review https://github.com/org/repo/pull/12345` - Use full PR URL
+- `/address-review https://github.com/org/repo/pull/12345#pullrequestreview-123456789` - Fetch specific review
+
+**Installation:**
+
+Copy `commands/address-review.md` to your `~/.claude/commands/` directory:
+
+```bash
+cp commands/address-review.md ~/.claude/commands/
+```
+
+## Contributing
+
+Add new commands, agents, or skills by creating appropriately named markdown files in their respective directories.

--- a/commands/address-review.md
+++ b/commands/address-review.md
@@ -1,0 +1,57 @@
+---
+description: Fetch GitHub PR review comments and create todos to address them
+---
+
+Fetch review comments from a GitHub PR in this repository and create a todo list to address each comment.
+
+# Instructions
+
+1. **Determine the current repository:**
+   ```bash
+   REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
+   ```
+
+2. Extract the PR number and optional review ID from the user's message:
+   - PR number only: "12345" or "https://github.com/org/repo/pull/12345"
+   - Specific review: "https://github.com/org/repo/pull/12345#pullrequestreview-123456789"
+   - Extract review ID from the hash fragment (e.g., "123456789")
+   - If a full GitHub URL is provided, extract the org/repo from the URL instead of using the current repo
+
+3. Fetch review comments:
+
+   **If a specific review ID is provided:**
+   ```bash
+   gh api repos/${REPO}/pulls/{PR_NUMBER}/reviews/{REVIEW_ID}/comments | jq '[.[] | {path: .path, body: .body, line: .line, start_line: .start_line, user: .user.login}]'
+   ```
+
+   **If only PR number is provided:**
+   ```bash
+   gh api repos/${REPO}/pulls/{PR_NUMBER}/comments | jq '[.[] | {path: .path, body: .body, line: .line, start_line: .start_line, user: .user.login}]'
+   ```
+
+4. Parse the JSON output and create a todo list with TodoWrite containing:
+   - One todo per review comment
+   - Format: "{file}:{line} - {comment_summary} (@{username})" (content)
+   - Format: "Addressing {file}:{line}" (activeForm)
+   - All todos should start with status: "pending"
+
+5. Present the todos to the user - DO NOT automatically start addressing them
+   - Show a summary of how many comments were found
+   - List the todos clearly
+   - Wait for the user to tell you which ones to address
+
+# Example Usage
+
+User: `/address-review https://github.com/org/repo/pull/12345#pullrequestreview-123456789`
+User: `/address-review 12345`
+User: `/address-review https://github.com/org/repo/pull/12345`
+
+# Important Notes
+
+- Automatically detect the repository using `gh repo view` for the current working directory
+- If a GitHub URL is provided, extract the org/repo from the URL
+- Include file path and line number in each todo for easy navigation
+- Include the reviewer's username in the todo text
+- If a comment doesn't have a specific line number, note it as "general comment"
+- **NEVER automatically address all review comments** - always wait for user direction
+- When given a specific review URL, no need to ask for more information


### PR DESCRIPTION
## Summary

- Create commands directory with `/address-review` command
- Update README with comprehensive documentation
- Add installation instructions for team members

## Details

The `/address-review` command allows fetching GitHub PR review comments and creating todos to address them. Supports:
- PR numbers
- Full PR URLs
- Specific review URLs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded README with About section describing available resources
  * Added installation instructions for commands
  * Added Contributing guidance for extending functionality

* **New Features**
  * Introduced /address-review command to transform GitHub PR review comments into a structured todo list
  * Supports fetching from specific reviews or entire pull requests via PR number or URL

<!-- end of auto-generated comment: release notes by coderabbit.ai -->