### PR TITLE
Add chrome-mcp script for MCP browser debugging

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,51 @@ cp commands/review-all-prs.md ~/.claude/commands/
 - Full usage guide: [docs/review-all-prs-usage.md](docs/review-all-prs-usage.md)
 - Example review: [docs/sample-review-output.md](docs/sample-review-output.md)
 
+## Scripts
+
+### `bin/chrome-mcp`
+
+Launches Google Chrome with a separate profile configured for MCP (Model Context Protocol) browser debugging. This keeps your MCP/debugging session isolated from your regular browsing.
+
+**Features:**
+- Dedicated Chrome profile for MCP tools
+- Remote debugging enabled on port 9222
+- Default URL or custom URL support
+- Clean separation from regular Chrome browsing
+
+**Usage:**
+
+```bash
+# Launch with default URL
+./bin/chrome-mcp
+
+# Launch with custom URL
+./bin/chrome-mcp https://example.com
+```
+
+**Installation:**
+
+Copy to your local bin directory and make it executable:
+
+```bash
+cp bin/chrome-mcp ~/bin/chrome-mcp
+chmod +x ~/bin/chrome-mcp
+```
+
+**What it does:**
+- Creates/uses a dedicated Chrome profile at `~/Library/Application Support/Google/Chrome-MCP-Profile`
+- Enables remote debugging on `localhost:9222`
+- Opens Chrome in a separate window that can be controlled via MCP browser tools in Conductor
+- Displays helpful debugging information and verification commands
+
+**Verify it's working:**
+
+```bash
+curl http://localhost:9222/json/version
+```
+
+You should see JSON output with Chrome debugging information.
+
 ## Contributing
 
 Add new commands, agents, or skills by creating appropriately named markdown files in their respective directories.

--- a/bin/chrome-mcp
+++ b/bin/chrome-mcp
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+# Start Chrome with a separate profile for MCP/debugging
+# This keeps it isolated from your regular browsing
+
+CHROME_APP="/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
+PROFILE_DIR="$HOME/Library/Application Support/Google/Chrome-MCP-Profile"
+DEBUGGING_PORT=9222
+
+# Allow passing a URL as first argument, default to PR review app
+URL="${1:-https://rails-pdzxq1kxxwqg8.cpln.app/}"
+
+echo "🚀 Starting Chrome with MCP profile..."
+echo "📁 Profile: $PROFILE_DIR"
+echo "🔌 Debug port: $DEBUGGING_PORT"
+echo "🌐 Opening: $URL"
+echo ""
+echo "✋ To stop: Close the Chrome window or press Ctrl+C here"
+echo ""
+
+"$CHROME_APP" \
+  --user-data-dir="$PROFILE_DIR" \
+  --remote-debugging-port=$DEBUGGING_PORT \
+  --remote-debugging-address=127.0.0.1 \
+  --no-first-run \
+  --no-default-browser-check \
+  "$URL" &
+
+CHROME_PID=$!
+echo "✅ Chrome started with PID: $CHROME_PID"
+echo ""
+echo "🔍 Verify debugging is working:"
+echo "   curl http://localhost:9222/json/version"
+echo ""
+echo "🤖 You can now use MCP browser tools in Conductor!"
+
+# Wait for Chrome process
+wait $CHROME_PID


### PR DESCRIPTION
## Summary

- Added `bin/chrome-mcp` script that launches Chrome with a dedicated profile for MCP browser tool integration
- Updated README.md with comprehensive documentation including installation, usage, and verification instructions

## What it does

The `chrome-mcp` script provides:
- Isolated Chrome profile for debugging/MCP work (keeps it separate from regular browsing)
- Remote debugging enabled on port 9222
- Support for custom URLs or uses a default URL
- Clear user feedback and verification steps

## Installation

Users can copy the script to their local bin directory:
```bash
cp bin/chrome-mcp ~/bin/chrome-mcp
chmod +x ~/bin/chrome-mcp
```

## Usage

```bash
# Launch with default URL
./bin/chrome-mcp

# Launch with custom URL
./bin/chrome-mcp https://example.com
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)