### PR TITLE
Add shared address-review prompt

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,19 @@
+# claude-code-commands-skills-agents
+
+## Project Overview
+
+This repository stores reusable AI workflows and supporting documentation.
+
+- `commands/`: Claude Code slash commands
+- `prompts/`: shared prompt templates for Codex, GPT, and other non-Claude tools
+- `agents/`: Claude agents
+- `docs/`: usage guides and supporting documentation
+- `templates/`: starter instruction files for other repositories
+
+## Working Rules
+
+- Keep reusable assets generic across repositories that use `gh`.
+- Treat `commands/` as Claude-only slash commands.
+- Treat `prompts/` as the canonical place for workflows meant to be pasted into Codex, GPT, or other tools without Claude slash commands.
+- When the user asks to address PR review comments outside Claude slash commands, follow `prompts/address-review.md`.
+- README is the human discovery surface. Update it whenever you add or rename a reusable asset.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # claude-code-commands-skills-agents
 
-ShakaCode Team Shared Claude Code and Codex CLI Commands, Agents, Skills, and Tips.
+ShakaCode Team Shared Claude Code commands plus cross-tool prompts, agents, skills, and tips.
 
 ## Quick Install
 
@@ -37,6 +37,16 @@ For project-level sharing, copy to your project's `.claude/commands/` or `.claud
 | [`/optimize`](commands/optimize.md) | Analyze code for performance issues with structured recommendations |
 | [`/security-review`](commands/security-review.md) | Review code for security vulnerabilities (OWASP Top 10 checklist) |
 | [`/file-by-file-review`](commands/file-by-file-review.md) | Review massive PRs file-by-file with parallel subagents (credit: [Romex91](https://github.com/Romex91/claude-code-file-by-file-review)) |
+
+## Prompt Templates
+
+Use these when you want a reusable workflow outside Claude Code's slash-command system:
+
+| Prompt | Description |
+|--------|-------------|
+| [`address-review`](prompts/address-review.md) | Shared prompt for Codex, GPT, or another coding assistant that mirrors `/address-review` and falls back cleanly when terminal access is unavailable |
+
+Prompt templates are not auto-installed commands. For Codex, point `AGENTS.md` at the prompt you want used. For GPT, paste the prompt into a session or add it to your project or custom instructions.
 
 ## Agents
 
@@ -88,7 +98,8 @@ Starter templates for new projects:
 ## Contributing
 
 1. Add new commands to `commands/`
-2. Add new agents to `agents/`
-3. Add documentation to `docs/`
-4. Keep everything generic -- project-specific instructions belong in project CLAUDE.md files
-5. All files must end with a newline character
+2. Add new prompt templates to `prompts/` when the workflow targets Codex, GPT, or other non-Claude tools
+3. Add new agents to `agents/`
+4. Add documentation to `docs/`
+5. Keep everything generic -- project-specific instructions belong in project CLAUDE.md files
+6. All files must end with a newline character

--- a/prompts/address-review.md
+++ b/prompts/address-review.md
@@ -1,0 +1,119 @@
+# Address Review Prompt
+
+Use this prompt in Codex CLI, ChatGPT, or another coding assistant when you want the equivalent of Claude Code's `/address-review` workflow.
+
+## How to Use
+
+Paste the prompt below into your coding assistant and replace `{{PR_REFERENCE}}` with one of:
+
+- A PR number, such as `12345`
+- A PR URL, such as `https://github.com/org/repo/pull/12345`
+- A specific review URL, such as `https://github.com/org/repo/pull/12345#pullrequestreview-123456789`
+- A specific issue comment URL, such as `https://github.com/org/repo/pull/12345#issuecomment-123456789`
+
+If the assistant has terminal access with `gh`, it should execute the workflow directly. If it does not, it should stop and ask for the missing GitHub data instead of pretending it fetched comments.
+
+## Prompt
+
+```text
+Act as a pull request review triage assistant.
+
+I want the equivalent of Claude Code's `/address-review` command for this input: `{{PR_REFERENCE}}`.
+
+Your job is to fetch GitHub PR review comments, triage them, and wait for my instruction before making code changes.
+
+Behavior rules:
+- Do not claim you fetched comments unless you actually have terminal or API access and used it.
+- If you do not have shell access with `gh`, say so immediately and ask me to provide either:
+  - the PR URL plus exported comment data, or
+  - the output of the required `gh api` commands.
+- Do not auto-fix everything. Stop after triage and wait for my selection.
+- Default to real issues only, not optional polish.
+- After selected items are addressed, reply to the original GitHub comments and resolve threads when appropriate.
+
+Execution flow when terminal access is available:
+
+1. Determine repository:
+   - Run: `REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)`
+   - If the input is a full GitHub URL, use the URL's `org/repo`.
+   - If `gh` is unavailable or unauthenticated, stop and tell me to fix that first.
+
+2. Parse the input:
+   - Support:
+     - PR number only
+     - PR URL
+     - Specific review URL with `#pullrequestreview-...`
+     - Specific issue comment URL with `#issuecomment-...`
+   - Extract the PR number and optional review/comment ID.
+
+3. Fetch review data:
+   - Specific issue comment:
+     `gh api repos/${REPO}/issues/comments/{COMMENT_ID} | jq '{body: .body, user: .user.login, html_url: .html_url}'`
+   - Specific review:
+     `gh api repos/${REPO}/pulls/{PR_NUMBER}/reviews/{REVIEW_ID} | jq '{id: .id, body: .body, state: .state, user: .user.login, html_url: .html_url}'`
+     `gh api --paginate repos/${REPO}/pulls/{PR_NUMBER}/reviews/{REVIEW_ID}/comments | jq -s '[.[].[] | {id: .id, node_id: .node_id, path: .path, body: .body, line: .line, start_line: .start_line, user: .user.login, in_reply_to_id: .in_reply_to_id}]'`
+   - Full PR:
+     `gh api --paginate repos/${REPO}/pulls/{PR_NUMBER}/comments | jq -s '[.[].[] | {id: .id, node_id: .node_id, type: "review", path: .path, body: .body, line: .line, start_line: .start_line, user: .user.login, in_reply_to_id: .in_reply_to_id}]'`
+     `gh api --paginate repos/${REPO}/issues/{PR_NUMBER}/comments | jq -s '[.[].[] | {id: .id, node_id: .node_id, type: "issue", body: .body, user: .user.login, html_url: .html_url}]'`
+   - For all review-comment paths, fetch thread metadata and match `thread_id` by `node_id`:
+     `OWNER=${REPO%/*}`
+     `NAME=${REPO#*/}`
+     `gh api graphql --paginate -f owner="${OWNER}" -f name="${NAME}" -F pr={PR_NUMBER} -f query='query($owner:String!, $name:String!, $pr:Int!, $endCursor:String) { repository(owner:$owner, name:$name) { pullRequest(number:$pr) { reviewThreads(first:100, after:$endCursor) { nodes { id isResolved comments(first:100) { nodes { id databaseId } } } pageInfo { hasNextPage endCursor } } } } }' | jq -s '[.[].data.repository.pullRequest.reviewThreads.nodes[] | {thread_id: .id, is_resolved: .isResolved, comments: [.comments.nodes[] | {node_id: .id, id: .databaseId}]}]'`
+
+4. Filter comments:
+   - Skip resolved threads.
+   - Skip replies where `in_reply_to_id` is set.
+   - Keep bot comments by default, but deduplicate duplicates and skip status-only bot posts.
+   - Focus on correctness bugs, regressions, security issues, missing tests that hide bugs, and clear adjacent-code inconsistencies.
+   - Skip style nits, speculative suggestions, documentation nits, changelog wording, duplicate comments, and "could consider" feedback unless I ask for polish work.
+   - If the API returns 404, tell me the PR or comment does not exist.
+   - If the API returns 403, tell me to check `gh auth status`.
+   - If nothing is returned, tell me no review comments were found.
+
+5. Triage every remaining comment:
+   - `MUST-FIX`: correctness bugs, regressions, security issues, missing tests that could hide a bug, and clear inconsistencies with adjacent code that would likely block merge.
+   - `DISCUSS`: reasonable scope-expanding suggestions, architectural opinions, and comments that need a decision.
+   - `SKIPPED`: style preferences, documentation nits, comment requests, test-shape preferences, speculative suggestions, changelog wording, duplicate comments, status posts, summaries, and factually incorrect suggestions.
+   - Deduplicate overlapping comments before classifying them.
+   - Verify reviewer claims locally before calling something `MUST-FIX`.
+   - If a claim is wrong, classify it as `SKIPPED` and say why.
+   - Preserve comment IDs and thread IDs for later replies and thread resolution.
+   - Track only `MUST-FIX` items as your working checklist.
+   - Use one checklist entry per must-fix item or deduplicated issue.
+   - Use the subject format: `"{file}:{line} - {comment_summary} (@{username})"`.
+   - For general comments, extract the must-fix action from the body.
+
+6. Present triage and wait:
+   - Use a single numbering sequence across all categories.
+   - Show counts for `MUST-FIX`, `DISCUSS`, and `SKIPPED`.
+   - Ask which items I want addressed.
+   - If there are skipped or declined discuss items, also ask which ones should receive rationale replies.
+   - Do not edit code yet.
+
+7. After I choose items:
+   - Address the selected items in code, tests, or docs.
+   - Run relevant checks when possible.
+   - Reply to each addressed review comment:
+     - Issue comments: `gh api repos/${REPO}/issues/{PR_NUMBER}/comments -X POST -f body="<response>"`
+     - Review comment replies: `gh api repos/${REPO}/pulls/{PR_NUMBER}/comments/{COMMENT_ID}/replies -X POST -f body="<response>"`
+     - Review summary body replies: `gh api repos/${REPO}/issues/{PR_NUMBER}/comments -X POST -f body="<response>"`
+   - Resolve threads only when the issue is actually handled or explicitly declined with my approval:
+     `gh api graphql -f query='mutation($threadId:ID!) { resolveReviewThread(input:{threadId:$threadId}) { thread { id isResolved } } }' -f threadId="<THREAD_ID>"`
+   - Do not resolve anything still in progress or uncertain.
+
+Output format for the triage:
+
+MUST-FIX (count):
+1. item
+
+DISCUSS (count):
+2. item
+   Reason: short explanation
+
+SKIPPED (count):
+3. item - short reason
+
+Then ask:
+- Which items should I address?
+- Optional: which skipped or declined items should get rationale replies?
+```


### PR DESCRIPTION
## Summary
- add a shared `prompts/address-review.md` template for Codex, GPT, and similar coding assistants
- add a root `AGENTS.md` that points Codex at the shared prompt for review-addressing requests
- update the README to document the new `prompts/` area and explain how prompt templates are used

## Testing
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that adds a reusable prompt and updates repo guidance; no runtime code paths are affected.
> 
> **Overview**
> Adds a new `prompts/address-review.md` template that mirrors the `/address-review` workflow for non-Claude tools, including explicit rules for when `gh` access is unavailable and a structured triage/output format.
> 
> Introduces a root `AGENTS.md` to define repository conventions and direct review-addressing requests to the shared prompt, and updates `README.md` to document the new `prompts/` area and contribution guidance.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 548c5768dbbe0f8551629daf5cf6a84220653308. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->