### PR TITLE
Add /docs skill for professional documentation generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ cp commands/*.md ~/.claude/commands/
 mkdir -p ~/.claude/agents
 cp agents/*.md ~/.claude/agents/
 
+# Install all skills
+mkdir -p ~/.claude/skills
+cp -r skills/* ~/.claude/skills/
+
 # Or install specific ones
 cp commands/self-review.md ~/.claude/commands/
 cp commands/merge-commit-msg.md ~/.claude/commands/
@@ -55,6 +59,26 @@ Prompt templates are not auto-installed commands. For Codex, point `AGENTS.md` a
 | [`pr-testing-agent`](agents/pr-testing-agent.md) | Identify and run only the tests affected by PR changes |
 
 Install to `~/.claude/agents/` (personal) or `.claude/agents/` (project).
+
+## Skills
+
+Skills are invoked via `/skill-name` in Claude Code. Install by adding this repo via `--add-dir`:
+
+```bash
+claude --add-dir /path/to/claude-code-commands-skills-agents/skills
+```
+
+Or configure in your project's `.claude/settings.json`:
+
+```json
+{
+  "additionalDirectories": ["/path/to/claude-code-commands-skills-agents/skills"]
+}
+```
+
+| Skill | Description |
+| --- | --- |
+| [`/docs`](skills/docs/SKILL.md) | Generate, audit, or update project documentation to a professional open-source standard. Covers README, quick start, API reference, config reference, migration guides, troubleshooting, LLMs.txt, and inline code docs (YARD/TSDoc). Benchmarked against Inertia Rails and Vite Ruby documentation. |
 
 ## Templates
 
@@ -150,6 +174,7 @@ See the [templates/](templates/) directory for starter `CLAUDE.md` and `AGENTS.m
 1. Add new commands to `commands/`
 2. Add new prompt templates to `prompts/` when the workflow targets Codex, GPT, or other non-Claude tools
 3. Add new agents to `agents/`
-4. Add documentation to `docs/`
-5. Keep everything generic -- project-specific instructions belong in project CLAUDE.md files
-6. All files must end with a newline character
+4. Add new skills to `skills/`
+5. Add documentation to `docs/`
+6. Keep everything generic -- project-specific instructions belong in project CLAUDE.md files
+7. All files must end with a newline character

--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ Starter templates for new projects:
 | Script | Description |
 |--------|-------------|
 | [`bin/sync-commands`](bin/sync-commands) | Sync commands from this repo into a target project's `.claude/commands/` |
+| [`bin/sync-skills`](bin/sync-skills) | Sync skills from this repo into a target project's `.claude/skills/` |
 | [`bin/chrome-mcp`](bin/chrome-mcp) | Launch Chrome with a separate profile for MCP browser debugging |
 | `bin/set-review-instructions` | Initialize file-by-file review with instructions and changed file list |
 | `bin/print-git-diff` | Print diff, before/after, and review instructions for a single file |
@@ -120,9 +121,9 @@ Starter templates for new projects:
 | [Claude Code Review](.github/workflows/claude-code-review.yml) | Automatic PR review on open/sync |
 | [Claude Code](.github/workflows/claude.yml) | Respond to `@claude` mentions in issues/PRs |
 
-## Syncing Commands to Your Project
+## Syncing to Your Project
 
-This repo is the canonical source for shared commands like `/address-review`. To keep a project in sync:
+This repo is the canonical source for shared commands and skills. Use the sync scripts to keep a project up to date.
 
 ### One-Time Setup
 
@@ -144,7 +145,7 @@ cp "$BOOSTERS/commands/address-review.md" .claude/commands/
 
 ### Keeping Up to Date
 
-Run `bin/sync-commands` from this repo to pull the latest commands into a target project:
+Run the sync scripts from this repo to pull the latest commands or skills into a target project:
 
 ```bash
 # Sync all commands to a project
@@ -152,6 +153,12 @@ Run `bin/sync-commands` from this repo to pull the latest commands into a target
 
 # Sync a specific command
 ./bin/sync-commands ~/projects/my-app address-review
+
+# Sync all skills to a project
+./bin/sync-skills ~/projects/my-app
+
+# Sync a specific skill
+./bin/sync-skills ~/projects/my-app docs
 ```
 
 ### For AI Agents in Consuming Repos
@@ -159,12 +166,12 @@ Run `bin/sync-commands` from this repo to pull the latest commands into a target
 Add this to your project's `CLAUDE.md` or `AGENTS.md` so agents know where shared commands come from:
 
 ```markdown
-## Shared Commands
+## Shared Commands and Skills
 
-The `/address-review` command is synced from
+Commands and skills are synced from
 [claude-code-commands-skills-agents](https://github.com/shakacode/claude-code-commands-skills-agents).
-Do not edit `.claude/commands/address-review.md` directly — update the
-canonical copy in the boosters repo and re-sync.
+Do not edit `.claude/commands/` or `.claude/skills/` directly — update the
+canonical copies in the boosters repo and re-sync.
 ```
 
 See the [templates/](templates/) directory for starter `CLAUDE.md` and `AGENTS.md` files that include this pattern.

--- a/README.md
+++ b/README.md
@@ -19,10 +19,6 @@ cp commands/*.md ~/.claude/commands/
 mkdir -p ~/.claude/agents
 cp agents/*.md ~/.claude/agents/
 
-# Install all skills
-mkdir -p ~/.claude/skills
-cp -r skills/* ~/.claude/skills/
-
 # Or install specific ones
 cp commands/self-review.md ~/.claude/commands/
 cp commands/merge-commit-msg.md ~/.claude/commands/

--- a/bin/sync-skills
+++ b/bin/sync-skills
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+#
+# Sync skills from this repo into a target project's .claude/skills/ directory.
+#
+# Usage:
+#   ./bin/sync-skills <target-project-path> [skill-name]
+#
+# Examples:
+#   ./bin/sync-skills ~/projects/my-app          # Sync all skills
+#   ./bin/sync-skills ~/projects/my-app docs      # Sync one skill
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+SKILLS_DIR="$REPO_ROOT/skills"
+
+if [ $# -lt 1 ]; then
+  echo "Usage: $(basename "$0") <target-project-path> [skill-name]"
+  echo ""
+  echo "Syncs skills from claude-code-commands-skills-agents into a project."
+  echo ""
+  echo "Examples:"
+  echo "  $(basename "$0") ~/projects/my-app"
+  echo "  $(basename "$0") ~/projects/my-app docs"
+  exit 1
+fi
+
+TARGET="$1"
+SKILL="${2:-}"
+
+if [ ! -d "$TARGET" ]; then
+  echo "Error: target directory does not exist: $TARGET"
+  exit 1
+fi
+
+TARGET_DIR="$TARGET/.claude/skills"
+mkdir -p "$TARGET_DIR"
+
+if [ -n "$SKILL" ]; then
+  SOURCE="$SKILLS_DIR/$SKILL"
+  if [ ! -d "$SOURCE" ]; then
+    echo "Error: skill not found: $SOURCE"
+    echo "Available skills:"
+    for d in "$SKILLS_DIR"/*/; do
+      [ -d "$d" ] && echo "  $(basename "$d")"
+    done
+    exit 1
+  fi
+  cp -r "$SOURCE" "$TARGET_DIR/"
+  echo "Synced $SKILL -> $TARGET_DIR/$SKILL/"
+else
+  for d in "$SKILLS_DIR"/*/; do
+    [ -d "$d" ] || continue
+    SKILL_NAME="$(basename "$d")"
+    cp -r "$d" "$TARGET_DIR/"
+    echo "Synced $SKILL_NAME -> $TARGET_DIR/$SKILL_NAME/"
+  done
+fi
+
+echo ""
+echo "Done. Skills are now in $TARGET_DIR/"
+echo ""
+echo "To use skills, add the skills directory via --add-dir or settings.json:"
+echo "  claude --add-dir $TARGET_DIR"
+echo "  Or add to .claude/settings.json: {\"additionalDirectories\": [\"$TARGET_DIR\"]}"

--- a/skills/docs/SKILL.md
+++ b/skills/docs/SKILL.md
@@ -7,17 +7,13 @@ description: Generate, audit, or update project documentation to a professional 
 
 Generate and maintain documentation that meets or exceeds the standard set by the best open-source Rails/JS projects (Inertia Rails, Vite Ruby, Rails itself).
 
-## Reference: Quality Standard
+## Before You Start
 
-!`cat "$(dirname "$0")/references/quality-standard.md"`
+Read these reference files (located in the `references/` subdirectory next to this SKILL.md file) before proceeding:
 
-## Reference: Documentation Templates
-
-!`cat "$(dirname "$0")/references/templates.md"`
-
-## Reference: Competitive Landscape
-
-!`cat "$(dirname "$0")/references/competitive-landscape.md"`
+1. **Quality Standard** — `references/quality-standard.md` — tiered audit checklist (Must-Have / Expected / Differentiator)
+2. **Documentation Templates** — `references/templates.md` — structural skeletons for each doc type
+3. **Competitive Landscape** — `references/competitive-landscape.md` — benchmarks against peer projects
 
 ## Workflow
 

--- a/skills/docs/SKILL.md
+++ b/skills/docs/SKILL.md
@@ -1,0 +1,149 @@
+---
+name: docs
+description: Generate, audit, or update project documentation to a professional open-source standard. Use this skill whenever the user mentions docs, documentation, README, API reference, guides, migration guides, troubleshooting, llms.txt, doc audit, or wants to improve any written developer-facing content in a repository. Also trigger when the user says things like "document this", "write docs for", "update the docs", "our docs need work", or compares documentation quality to other projects. Covers Ruby (YARD), TypeScript (TSDoc/JSDoc), Markdown guides, configuration references, and doc site structure.
+---
+
+# Documentation Skill
+
+Generate and maintain documentation that meets or exceeds the standard set by the best open-source Rails/JS projects (Inertia Rails, Vite Ruby, Rails itself).
+
+## Before You Start
+
+1. Read `references/quality-standard.md` in this skill directory to understand the bar we are targeting.
+2. Read `references/templates.md` for structural templates by doc type.
+
+## Workflow
+
+### Step 1: Assess the current state
+
+- Scan the repo for existing docs: `docs/`, `README.md`, `CHANGELOG.md`, `CONTRIBUTING.md`, inline code comments, Wiki, and any hosted doc site config (VitePress, Docusaurus, Jekyll, etc.)
+- Identify what exists, what is outdated, and what is missing
+- Compare against the quality checklist in `references/quality-standard.md`
+
+### Step 2: Determine scope
+
+If the user gave a specific target (e.g., `/docs $ARGUMENTS`), focus there. Otherwise, present a prioritized gap analysis:
+
+1. **Critical gaps** - Missing README sections, no quick start, no API reference
+2. **High-value improvements** - Outdated guides, missing migration/upgrade docs, no troubleshooting
+3. **Polish** - LLMs.txt, cookbook/recipes, configuration reference, contributor guide improvements
+
+Ask the user which items to tackle (or do all if they say so).
+
+### Step 3: Generate or rewrite documentation
+
+Follow these principles for ALL documentation:
+
+#### Voice and Style
+- **Direct and concise.** Lead with what the reader needs. No filler.
+- **Show, don't tell.** Every concept gets a code example. Prefer real-world examples over contrived ones.
+- **Progressive disclosure.** Quick start first, then deeper guides, then API reference. Layer complexity.
+- **Avoid em dashes** (use commas, parentheses, or separate sentences instead).
+- **Use second person** ("you") for guides and tutorials. Use third person for API references.
+- **Prefer active voice.** "Run `bundle install`" not "The bundle should be installed."
+
+#### Structure by Doc Type
+
+**README.md** (the front door):
+- One-liner description + badges
+- "What is this?" in 2-3 sentences
+- Quick install (copy-paste ready)
+- Minimal "Hello World" example that works
+- Link table to deeper docs
+- Requirements / compatibility matrix
+- Community links (Slack, Discussions, Stack Overflow)
+- Contributing pointer
+- License
+
+**Quick Start Guide** (< 15 minutes):
+- Prerequisites with exact version requirements
+- Step-by-step, numbered instructions
+- Every command is copy-paste ready
+- "You should see..." verification checkpoints after key steps
+- Link to "next steps" at the end
+
+**Conceptual Guides** (explain "why" and "how"):
+- Start with a one-paragraph summary of what the reader will learn
+- Use diagrams (Mermaid or ASCII) for architecture and data flow
+- Break into logical sections with clear headings
+- End each guide with "Related" links
+
+**API / Helper Reference**:
+- One page per module or helper group
+- Signature, parameters table, return value, exceptions
+- At least one usage example per method
+- For Ruby: follow YARD conventions (`@param`, `@return`, `@example`)
+- For TypeScript: follow TSDoc conventions (`@param`, `@returns`, `@example`)
+
+**Configuration Reference**:
+- Table format: option name, type, default, description
+- Group by category
+- Include example config file (annotated with comments)
+
+**Migration / Upgrade Guide**:
+- Version-to-version, with exact steps
+- "Breaking changes" section at top
+- "Deprecations" section
+- Automated migration commands if available
+- Before/after code comparisons
+
+**Troubleshooting / FAQ**:
+- Problem statement as the heading (what the user sees or encounters)
+- Cause explanation (1-2 sentences)
+- Solution with exact commands or code
+- "Still stuck?" pointer to community support
+
+**LLMs.txt** (AI-friendly docs):
+- `/llms.txt` with a structured overview and links to key pages
+- `/llms-full.txt` with complete documentation in a single Markdown file
+- Follow the llms.txt specification: title, description, sections with URLs
+- Include on every docs page: "Are you an LLM? View /llms.txt for optimized documentation"
+
+### Step 4: Cross-reference and link
+
+- Every guide should link to related guides
+- Every API method mentioned in a guide should link to its reference page
+- Add a "See also" or "Related" section at the bottom of each page
+- Verify no dead links (check file paths exist)
+
+### Step 5: Review with the user
+
+Present the generated docs and ask:
+- "Does this match how your project actually works?"
+- "Any terminology or naming I got wrong?"
+- "Anything missing for your users?"
+
+## Targeting Specific Files
+
+When invoked as `/docs <target>`:
+- If `<target>` is a file path: generate/update docs FOR that code file (inline comments, module-level docs, method docs)
+- If `<target>` is a directory: generate/update docs for the entire module
+- If `<target>` is a doc type keyword (e.g., "readme", "api", "quickstart", "migration", "troubleshooting", "llms.txt", "audit"): generate that specific doc type
+- If `<target>` is "audit": run a full gap analysis against `references/quality-standard.md` and report findings
+
+## Language-Specific Conventions
+
+### Ruby
+- Use YARD doc format for all public methods and classes
+- `@param name [Type] description`
+- `@return [Type] description`
+- `@raise [ExceptionClass] when condition`
+- `@example` with realistic usage
+- `@see` for cross-references
+- Document `@option` for hash parameters
+
+### TypeScript / JavaScript
+- Use TSDoc for TypeScript, JSDoc for JavaScript
+- `@param name - description`
+- `@returns description`
+- `@throws {ErrorType} description`
+- `@example` blocks with realistic usage
+- Export documentation: what is public API vs. internal
+- Document generic type parameters
+
+### Markdown Docs
+- Use ATX headings (`#`, `##`, `###`) not Setext
+- Fenced code blocks with language identifiers (```ruby, ```typescript, ```bash)
+- Use reference-style links for repeated URLs
+- Tables for configuration options and API parameter lists
+- Admonitions for warnings and tips (use blockquote style: `> **Note:** ...` or `> **Warning:** ...`)

--- a/skills/docs/SKILL.md
+++ b/skills/docs/SKILL.md
@@ -7,10 +7,17 @@ description: Generate, audit, or update project documentation to a professional 
 
 Generate and maintain documentation that meets or exceeds the standard set by the best open-source Rails/JS projects (Inertia Rails, Vite Ruby, Rails itself).
 
-## Before You Start
+## Reference: Quality Standard
 
-1. Read `references/quality-standard.md` in this skill directory to understand the bar we are targeting.
-2. Read `references/templates.md` for structural templates by doc type.
+!`cat "$(dirname "$0")/references/quality-standard.md"`
+
+## Reference: Documentation Templates
+
+!`cat "$(dirname "$0")/references/templates.md"`
+
+## Reference: Competitive Landscape
+
+!`cat "$(dirname "$0")/references/competitive-landscape.md"`
 
 ## Workflow
 
@@ -18,7 +25,7 @@ Generate and maintain documentation that meets or exceeds the standard set by th
 
 - Scan the repo for existing docs: `docs/`, `README.md`, `CHANGELOG.md`, `CONTRIBUTING.md`, inline code comments, Wiki, and any hosted doc site config (VitePress, Docusaurus, Jekyll, etc.)
 - Identify what exists, what is outdated, and what is missing
-- Compare against the quality checklist in `references/quality-standard.md`
+- Compare against the Quality Standard reference above
 
 ### Step 2: Determine scope
 
@@ -119,7 +126,7 @@ When invoked as `/docs <target>`:
 - If `<target>` is a file path: generate/update docs FOR that code file (inline comments, module-level docs, method docs)
 - If `<target>` is a directory: generate/update docs for the entire module
 - If `<target>` is a doc type keyword (e.g., "readme", "api", "quickstart", "migration", "troubleshooting", "llms.txt", "audit"): generate that specific doc type
-- If `<target>` is "audit": run a full gap analysis against `references/quality-standard.md` and report findings
+- If `<target>` is "audit": run a full gap analysis against the Quality Standard reference above and report findings
 
 ## Language-Specific Conventions
 

--- a/skills/docs/references/competitive-landscape.md
+++ b/skills/docs/references/competitive-landscape.md
@@ -1,0 +1,109 @@
+# Competitive Documentation Landscape
+
+Reference for understanding what competitors offer so we can match or exceed them.
+
+## React on Rails Competitors
+
+### Inertia Rails (inertia-rails.dev)
+**Stars:** ~3k (inertia-rails gem) | **Docs quality:** Excellent
+
+Doc site structure (VitePress at inertia-rails.dev):
+- Introduction, Demo app, Upgrade guide
+- Installation: Server-side, Client-side, Starter kits
+- Core concepts: Who is it for, How it works, The protocol
+- The basics: Pages, Responses, Redirects, Routing, Title & meta, Links, Manual visits, Forms, File uploads, Validation, View transitions
+- Data & Props: Shared data, Flash data, Partial reloads, Deferred props, Polling, Prefetching, Load when visible, Merging props, Once props, Infinite scroll, Remembering state
+- Security: Authentication, Authorization, CSRF protection, History encryption
+- Advanced: Asset versioning, Code splitting, Configuration, Error handling, Events, Progress indicators, Scroll management, SSR, Testing, TypeScript
+- Extras: Cookbook, Awesome list
+
+Key differentiators:
+- LLMs.txt and llms-full.txt for AI agents
+- "Are you an LLM?" notice on every page
+- Cookbook with practical recipes (shadcn/ui integration, etc.)
+- Three official starter kits
+- Every page editable on GitHub
+
+### Vite Ruby (vite-ruby.netlify.app)
+**Stars:** ~1.3k | **Docs quality:** Very good
+
+Doc site structure:
+- Introduction (motivation, comparison)
+- Getting Started (multi-framework install)
+- Development, Deployment, Advanced, Plugins
+- Rails Integration (tag helpers, asset handling)
+- Configuration Reference (every option in a table)
+- Troubleshooting
+- Overview (internals for curious devs)
+
+Key differentiators:
+- Clear framework-specific install paths
+- Recommended plugins page
+- Link to example app on Heroku
+
+### react-rails gem (github.com/reactjs/react-rails)
+**Stars:** ~6.7k | **Docs quality:** Below average
+
+- Single long README
+- Wiki with community-contributed articles
+- No dedicated docs site
+- Outdated examples in some areas
+- Migration guide to React on Rails exists (this is an opportunity)
+
+### Hotwire / Turbo (not a direct competitor but adjacent)
+**Docs quality:** Good (part of Rails guides)
+
+- Integrated into Rails official guides
+- Handbook at hotwired.dev
+- Clear separation: Turbo Drive, Turbo Frames, Turbo Streams
+
+## Shakapacker Competitors
+
+### Vite Ruby (same as above)
+The primary alternative to Shakapacker for JS bundling in Rails.
+
+### jsbundling-rails (github.com/rails/jsbundling-rails)
+**Stars:** ~1k | **Docs quality:** Minimal
+
+- Very short README
+- Relies on official Rails guides for context
+- No dedicated docs site
+- Simple by design (thin wrapper)
+
+### Webpacker (legacy, github.com/rails/webpacker)
+**Docs quality:** Moderate (archived)
+
+- Was the Rails default
+- README plus docs/ directory
+- Now deprecated; Shakapacker is the successor
+
+## What React on Rails / Shakapacker Should Target
+
+Based on competitive analysis, the minimum viable docs improvement:
+
+1. **Match Inertia Rails' structure** for doc site sidebar organization
+2. **Add LLMs.txt** (Inertia Rails has this; we should too)
+3. **Create a real Configuration Reference page** (Vite Ruby does this well)
+4. **Troubleshooting page** derived from top GitHub Issues
+5. **Cookbook section** with recipes for common setups (TypeScript, Redux, React Router, Tailwind, shadcn/ui)
+6. **Comparison page** that honestly compares React on Rails vs. Inertia vs. Vite Ruby vs. react-rails
+7. **Demo app** with source code and live link
+8. **Upgrade guides** for each major version with before/after code
+9. **AI agent instructions** (already exists, keep it updated)
+
+## Unique Strengths to Highlight in Docs
+
+React on Rails:
+- 10+ years of production use
+- Server-side rendering built in (Inertia only recently added SSR)
+- React Server Components support (via Pro)
+- Works with existing Rails views (progressive adoption)
+- No client-side routing required
+- Rspack support for faster builds
+
+Shakapacker:
+- Official successor to rails/webpacker
+- Drop-in replacement for webpacker
+- Active maintenance by ShakaCode
+- Webpack 5 with full configuration access
+- Rspack compatibility

--- a/skills/docs/references/quality-standard.md
+++ b/skills/docs/references/quality-standard.md
@@ -1,0 +1,141 @@
+# Documentation Quality Standard
+
+This checklist represents the bar set by the best Rails/JS open-source projects. Use it when auditing existing docs or planning new documentation.
+
+## Benchmarks
+
+The following projects represent the gold standard we aim to match or exceed:
+
+**Inertia Rails** (inertia-rails.dev):
+- Dedicated docs site with VitePress
+- Clear sidebar: Introduction > Installation > Core Concepts > Basics > Data & Props > Security > Advanced
+- LLMs.txt and llms-full.txt for AI-friendly access
+- Cookbook section with practical recipes
+- "Awesome" curated ecosystem list
+- Demo application with source code
+- Upgrade guide between major versions
+- Every page has "Edit on GitHub" link
+
+**Vite Ruby** (vite-ruby.netlify.app):
+- Clean structure: Introduction > Getting Started > Development > Deployment > Advanced > Plugins
+- Configuration reference as a dedicated page with every option documented
+- Framework-specific integration pages (Rails, Hanami, Padrino)
+- Recommended plugins page
+- Troubleshooting section
+- Overview page explaining internals for curious developers
+
+**Rails Guides** (guides.rubyonrails.org):
+- Numbered, progressive guides
+- "What you will learn" box at the start of each guide
+- Consistent voice and structure across all guides
+- Version switcher
+
+## Audit Checklist
+
+### Tier 1: Must-Have (blocks adoption if missing)
+
+- [ ] **README.md** with: one-liner, install command, minimal example, link table to docs
+- [ ] **Quick Start** that works in < 15 minutes on a fresh project
+- [ ] **Installation guide** with exact version requirements and copy-paste commands
+- [ ] **At least one complete tutorial** walking through a real use case end-to-end
+- [ ] **API/Helper reference** for all public-facing methods
+- [ ] **Configuration reference** with every option, its type, default, and description
+- [ ] **CHANGELOG.md** or equivalent release notes
+- [ ] **LICENSE** file
+
+### Tier 2: Expected (users will notice if missing)
+
+- [ ] **Upgrade / Migration guide** for each major version
+- [ ] **Troubleshooting / FAQ** covering the top 10 issues from GitHub Issues
+- [ ] **Contributing guide** (CONTRIBUTING.md)
+- [ ] **Architecture / How it works** explainer with a diagram
+- [ ] **Server-side rendering (SSR) guide** (if applicable)
+- [ ] **Deployment guide** for common platforms (Heroku, Render, Docker, Kamal)
+- [ ] **Testing guide** showing how to test components/integration
+- [ ] **Code of Conduct**
+
+### Tier 3: Differentiator (sets you apart)
+
+- [ ] **Dedicated docs site** (VitePress, Docusaurus, or similar)
+- [ ] **LLMs.txt** for AI agent consumption
+- [ ] **AI agent instructions** file for coding assistants (AGENTS.md or similar)
+- [ ] **Cookbook / Recipes** section with copy-paste solutions to common tasks
+- [ ] **Comparison page** vs. alternatives (honest, factual)
+- [ ] **Demo application** with source code and live deployment
+- [ ] **Video walkthroughs** or links to conference talks
+- [ ] **Ecosystem / Awesome list** of community plugins, tools, and integrations
+- [ ] **Versioned docs** with a version switcher
+- [ ] **Search functionality** on the docs site
+- [ ] **"Edit this page on GitHub"** links on every page
+- [ ] **i18n / Localization** guide (if the project supports it)
+
+## Doc Site Structure Template
+
+For projects that have or want a dedicated docs site, the recommended sidebar structure is:
+
+```
+Getting Started
+  ├── Introduction (what, why, who)
+  ├── Quick Start (< 15 min)
+  ├── Installation (detailed)
+  └── Demo Application
+
+Core Concepts
+  ├── How It Works (architecture diagram)
+  ├── Key Terminology
+  └── Comparison with Alternatives
+
+Guides
+  ├── Tutorial (full walkthrough)
+  ├── Server-Side Rendering
+  ├── TypeScript Integration
+  ├── Styling / CSS
+  ├── Testing
+  ├── Deployment
+  └── [Project-specific topics]
+
+API Reference
+  ├── Ruby API (View Helpers, Configuration, Generator)
+  ├── JavaScript API (Client module, Registration, Hooks)
+  └── CLI / Rake Tasks
+
+Configuration
+  └── Full Configuration Reference
+
+Advanced
+  ├── Performance Optimization
+  ├── Code Splitting
+  ├── Custom Webpack/Rspack Configuration
+  └── Extending / Plugin Development
+
+Resources
+  ├── Upgrade Guide
+  ├── Troubleshooting / FAQ
+  ├── Cookbook / Recipes
+  ├── Contributing
+  ├── Changelog
+  └── Ecosystem / Awesome List
+```
+
+## Writing Quality Signals
+
+When reviewing docs, check for these quality signals:
+
+**Good signs:**
+- Every code example is copy-paste ready and tested
+- Verification checkpoints ("You should see...")
+- Real-world examples, not `foo`/`bar`
+- Consistent heading hierarchy
+- Cross-links between related pages
+- Clear prerequisites at the start of each guide
+- "Next steps" at the end of each page
+
+**Red flags:**
+- Stale version numbers in examples
+- Broken links or references to removed features
+- "TODO" or "Coming soon" placeholders
+- Examples that assume context not provided
+- Inconsistent terminology (using different names for the same concept)
+- Missing code language identifiers on fenced blocks
+- Walls of text with no code examples
+- Em dashes (prefer commas or separate sentences)

--- a/skills/docs/references/templates.md
+++ b/skills/docs/references/templates.md
@@ -1,0 +1,423 @@
+# Documentation Templates
+
+Structural templates for each doc type. Adapt these to the specific project. Do not copy them verbatim; they are skeletons to fill in with real content.
+
+---
+
+## README.md Template
+
+```markdown
+# Project Name
+
+[![Gem Version](badge-url)](gem-url)
+[![npm version](badge-url)](npm-url)
+[![Build Status](badge-url)](ci-url)
+[![License: MIT](badge-url)](license-url)
+
+One-sentence description of what this project does and why it matters.
+
+## Why Project Name?
+
+2-3 sentences expanding on the value proposition. What problem does it solve?
+How does it differ from alternatives?
+
+## Quick Install
+
+\`\`\`bash
+# Ruby
+bundle add project_name --strict
+
+# JavaScript
+yarn add project-name
+\`\`\`
+
+## Hello World
+
+Minimal, complete, working example in < 20 lines total.
+
+\`\`\`ruby
+# In your Rails view
+<%= react_component("HelloWorld", props: { name: "Reader" }, prerender: false) %>
+\`\`\`
+
+\`\`\`typescript
+// In your component file
+import React from 'react';
+
+const HelloWorld = ({ name }: { name: string }) => (
+  <h1>Hello, {name}!</h1>
+);
+
+export default HelloWorld;
+\`\`\`
+
+## Documentation
+
+| Topic | Link |
+|-------|------|
+| Quick Start (15 min) | [docs/quick-start.md](docs/quick-start.md) |
+| Full Tutorial | [docs/tutorial.md](docs/tutorial.md) |
+| API Reference | [docs/api/README.md](docs/api/README.md) |
+| Configuration | [docs/configuration.md](docs/configuration.md) |
+| Upgrade Guide | [docs/upgrade.md](docs/upgrade.md) |
+| Troubleshooting | [docs/troubleshooting.md](docs/troubleshooting.md) |
+
+## Requirements
+
+- Ruby >= 3.0
+- Rails >= 6.1
+- Node >= 18
+- Shakapacker >= 6.0 (or Rspack)
+
+## Community
+
+- [GitHub Discussions](link)
+- [Slack Channel](link)
+- [Stack Overflow Tag](link)
+
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
+
+## License
+
+MIT. See [LICENSE](LICENSE).
+```
+
+---
+
+## Quick Start Guide Template
+
+```markdown
+# Quick Start
+
+Get your first [component/feature] running in under 15 minutes.
+
+## Prerequisites
+
+- Ruby [version] and Rails [version] (verify: `ruby -v && rails -v`)
+- Node [version] and Yarn [version] (verify: `node -v && yarn -v`)
+- A Rails application (or create one: `rails new myapp --skip-javascript`)
+
+## Step 1: Install dependencies
+
+\`\`\`bash
+bundle add project_name --strict
+bundle add shakapacker --strict
+\`\`\`
+
+## Step 2: Run the generator
+
+\`\`\`bash
+rails generate project_name:install
+\`\`\`
+
+> **You should see:** Output confirming files were created, including
+> `app/javascript/...` and configuration files.
+
+## Step 3: Start the development server
+
+\`\`\`bash
+bin/dev
+\`\`\`
+
+> **You should see:** Both Rails and the Webpack dev server start.
+> Visit `http://localhost:3000` in your browser.
+
+## Step 4: Verify it works
+
+Navigate to `http://localhost:3000/hello_world`. You should see a React
+component rendering with a greeting.
+
+## Step 5: Make a change
+
+Open `app/javascript/src/HelloWorld.jsx` and change the greeting text.
+Save the file. The browser should update automatically (HMR).
+
+## Next Steps
+
+- [Full Tutorial](tutorial.md) - Build a complete feature
+- [Server-Side Rendering](ssr.md) - Enable SSR for SEO
+- [Configuration Reference](configuration.md) - Customize your setup
+```
+
+---
+
+## API Reference Entry Template
+
+```markdown
+# `method_name`
+
+Brief one-line description of what this method does.
+
+## Signature
+
+\`\`\`ruby
+method_name(component_name, options = {}) -> String
+\`\`\`
+
+## Parameters
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `component_name` | `String` | Yes | - | The registered name of the React component |
+| `options` | `Hash` | No | `{}` | Configuration options (see below) |
+
+### Options
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `:props` | `Hash` | `{}` | Props passed to the React component |
+| `:prerender` | `Boolean` | `false` | Enable server-side rendering |
+| `:trace` | `Boolean` | `false` | Add HTML comments for debugging |
+
+## Return Value
+
+Returns an HTML `String` containing the rendered component markup and
+the JavaScript needed to hydrate it on the client.
+
+## Examples
+
+### Basic usage
+
+\`\`\`ruby
+<%= react_component("UserProfile", props: { user: @user }) %>
+\`\`\`
+
+### With server-side rendering
+
+\`\`\`ruby
+<%= react_component("UserProfile",
+  props: { user: @user.as_json(only: [:id, :name, :email]) },
+  prerender: true
+) %>
+\`\`\`
+
+## Notes
+
+- Component must be registered with `ReactOnRails.register({ UserProfile })`
+  before it can be rendered.
+- When using `prerender: true`, ensure your component does not depend on
+  browser-only APIs during initial render.
+
+## See Also
+
+- [`react_component_hash`](react_component_hash.md)
+- [Server-Side Rendering Guide](../guides/ssr.md)
+```
+
+---
+
+## Configuration Reference Template
+
+```markdown
+# Configuration Reference
+
+All configuration options for Project Name, with types, defaults,
+and descriptions.
+
+## Ruby Configuration
+
+Set these in `config/initializers/react_on_rails.rb`:
+
+\`\`\`ruby
+ReactOnRails.configure do |config|
+  config.server_bundle_js_file = "server-bundle.js"
+  config.prerender = false
+end
+\`\`\`
+
+### Options
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `server_bundle_js_file` | `String` | `""` | JS bundle used for server rendering. Relative to `generated_assets_dir`. |
+| `prerender` | `Boolean` | `false` | Default SSR setting for all components. Can be overridden per-component. |
+| `random_dom_id` | `Boolean` | `true` | Generate random DOM IDs for component containers. Set to `false` for deterministic IDs (useful in testing). |
+
+## JavaScript Configuration
+
+Configure in your webpack/rspack entry file:
+
+\`\`\`typescript
+import ReactOnRails from 'react-on-rails';
+
+ReactOnRails.setOptions({
+  traceTurbolinks: true,
+});
+\`\`\`
+
+### Options
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `traceTurbolinks` | `boolean` | `false` | Log Turbolinks events for debugging. |
+
+## Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `TRACE_REACT_ON_RAILS` | - | Enable verbose logging |
+```
+
+---
+
+## Troubleshooting Template
+
+```markdown
+# Troubleshooting
+
+Common issues and their solutions. If your problem is not listed here,
+search [GitHub Issues](link) or ask in [Discussions](link).
+
+## Component not rendering
+
+**What you see:** The page loads but the React component area is blank
+or shows raw HTML.
+
+**Common causes:**
+1. The component is not registered. Make sure you call
+   `ReactOnRails.register({ MyComponent })` in your entry file.
+2. The entry file is not included in the page. Check your
+   `javascript_pack_tag` or Shakapacker configuration.
+
+**Fix:**
+
+\`\`\`javascript
+// app/javascript/packs/application.js
+import ReactOnRails from 'react-on-rails';
+import MyComponent from '../components/MyComponent';
+
+ReactOnRails.register({ MyComponent });
+\`\`\`
+
+---
+
+## SSR fails with "ReferenceError: window is not defined"
+
+**What you see:** Server-side rendering crashes with a reference error
+for `window`, `document`, or other browser globals.
+
+**Cause:** Your component (or a dependency) accesses browser APIs
+during the initial render pass, which runs in a Node/ExecJS context
+where those globals do not exist.
+
+**Fix:** Guard browser-only code:
+
+\`\`\`typescript
+const isBrowser = typeof window !== 'undefined';
+
+useEffect(() => {
+  // Safe to use window here (only runs in browser)
+}, []);
+\`\`\`
+
+---
+
+## Still stuck?
+
+- Run `VERBOSE=true rake react_on_rails:doctor` for a diagnostic report
+- Search [GitHub Issues](link)
+- Ask in the [React + Rails Slack](link)
+- [Book a call with ShakaCode](link) for direct support
+```
+
+---
+
+## LLMs.txt Template
+
+```
+# Project Name
+
+> One-sentence description
+
+Project Name is [expanded description in 2-3 sentences].
+
+## Documentation
+
+- [Quick Start](https://example.com/docs/quick-start): Get running in 15 minutes
+- [Installation](https://example.com/docs/installation): Detailed setup instructions
+- [Tutorial](https://example.com/docs/tutorial): Build a complete feature step by step
+- [API Reference](https://example.com/docs/api): All public methods and helpers
+- [Configuration](https://example.com/docs/configuration): Every config option explained
+- [SSR Guide](https://example.com/docs/ssr): Server-side rendering setup and optimization
+- [Troubleshooting](https://example.com/docs/troubleshooting): Common issues and fixes
+- [Upgrade Guide](https://example.com/docs/upgrade): Migration between versions
+
+## Optional
+
+- [Architecture](https://example.com/docs/architecture): How it works under the hood
+- [Cookbook](https://example.com/docs/cookbook): Recipes for common patterns
+- [Contributing](https://example.com/contributing): How to contribute
+- [Changelog](https://example.com/changelog): Release history
+```
+
+---
+
+## Migration / Upgrade Guide Template
+
+```markdown
+# Upgrading from vX to vY
+
+This guide covers breaking changes, deprecations, and the steps to
+upgrade your application.
+
+## Breaking Changes
+
+### 1. Feature/API that changed
+
+**Before (vX):**
+
+\`\`\`ruby
+# Old way
+config.old_option = true
+\`\`\`
+
+**After (vY):**
+
+\`\`\`ruby
+# New way
+config.new_option = true
+\`\`\`
+
+**Migration:** Replace all occurrences of `old_option` with `new_option`
+in your initializer.
+
+### 2. Removed feature
+
+`some_deprecated_method` has been removed. Use `new_method` instead.
+
+## Deprecations
+
+The following are deprecated in vY and will be removed in v(Y+1):
+
+| Deprecated | Replacement | Remove in |
+|-----------|-------------|-----------|
+| `old_helper` | `new_helper` | vZ |
+
+## Automated Migration
+
+Run the generator to update configuration files automatically:
+
+\`\`\`bash
+rails generate project_name:install
+\`\`\`
+
+> **Warning:** Review the diff before committing. The generator may
+> overwrite custom configurations.
+
+## Step-by-Step Upgrade
+
+1. Update your Gemfile: `gem "project_name", "~> Y.0"`
+2. Run `bundle update project_name`
+3. Run `rails generate project_name:install` and review changes
+4. Update JavaScript: `yarn upgrade project-name@^Y.0`
+5. Run your test suite: `bundle exec rspec`
+6. Check for deprecation warnings in your Rails logs
+
+## Need Help?
+
+- [Troubleshooting Guide](troubleshooting.md)
+- [GitHub Discussions](link)
+- [ShakaCode Support](link)
+```


### PR DESCRIPTION
## Summary

- Adds a `/docs` skill for generating, auditing, and updating project documentation to a professional open-source standard
- Includes quality checklist benchmarked against Inertia Rails and Vite Ruby docs
- Includes structural templates for all doc types (README, quick start, API reference, config reference, migration guide, troubleshooting, LLMs.txt)
- Includes competitive landscape analysis of Rails/JS documentation
- Updates README with Skills section, install instructions, and contributing guidelines

## Files added

| File | Purpose |
| --- | --- |
| `skills/docs/SKILL.md` | Main skill: workflow, voice/style rules, doc type structures, language conventions |
| `skills/docs/references/quality-standard.md` | 3-tier audit checklist (must-have, expected, differentiator) |
| `skills/docs/references/templates.md` | Structural skeletons for all doc types |
| `skills/docs/references/competitive-landscape.md` | What Inertia Rails, Vite Ruby, react-rails, jsbundling-rails offer |

## Test plan

- [ ] Verify `/docs` skill is recognized when repo is added via `--add-dir`
- [ ] Run `/docs audit` against react_on_rails to confirm gap analysis works
- [ ] Run `/docs readme` to verify README generation follows templates
- [ ] Verify all reference files are readable from within the skill

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds documentation-only skill content and a standalone `bin/sync-skills` helper script, with no changes to runtime application logic or security-sensitive code.
> 
> **Overview**
> Adds a new Claude Code `/docs` skill (`skills/docs`) for generating/auditing repository documentation, backed by included reference materials (quality checklist, competitive landscape notes, and doc templates).
> 
> Updates `README.md` to document skills installation/usage, list the new `/docs` skill, and expand project sync guidance to cover both commands and skills. Introduces `bin/sync-skills`, mirroring `bin/sync-commands`, to copy skills into a consuming project’s `.claude/skills/` directory (optionally scoped to a single skill).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 78aae1b06b1ba951d14ad00be00038cd0c959e0d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added skills installation and configuration guide with CLI and settings-file options; docs describe invoking skills (e.g., /skill-name)
  * Introduced a Documentation Skill for generating, auditing, and updating repo docs with style, linking, and review rules
  * Added reference materials: quality-standards checklist, competitive landscape analysis, and reusable documentation templates

* **Chores / Tools**
  * Added a sync utility to copy skills into a target project and updated sync guidance and examples

* **Contributing**
  * Updated contribution checklist and consuming-repo guidance to include skills directory guidance
<!-- end of auto-generated comment: release notes by coderabbit.ai -->